### PR TITLE
fontのパスは/opt/node/jsを見ている動きだったので修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,4 @@ WORKDIR /opt/node/js
 
 RUN ["/bin/bash", "-c", "npm install"]
 
-RUN mv /opt/node/js/fonts/NotoSansCJKjp-Black.otf /usr/local/share/fonts/
-
 ENTRYPOINT node index.js


### PR DESCRIPTION
fontが見つからずコケていたのでpathを直しました

```bash
docker run -it -p 8088:8088 pistatium/unique_ogp
internal/fs/utils.js:269
    throw err;
    ^
Error: ENOENT: no such file or directory, lstat '/opt/node/js/fonts/NotoSansCJKjp-Black.otf'
    at Object.realpathSync (fs.js:1646:7)
    at registerFont (/opt/node/js/node_modules/canvas/index.js:48:34)
    at getArticon (/opt/node/js/index.js:12:5)
    at Server.<anonymous> (/opt/node/js/index.js:36:18)
    at Server.emit (events.js:314:20)
    at parserOnIncoming (_http_server.js:779:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:122:17) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/opt/node/js/fonts/NotoSansCJKjp-Black.otf'
}

```